### PR TITLE
Handle empty issue body when removing HTML

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -7,7 +7,7 @@ import type {InputPropertyValueMap} from '@notionhq/client/build/src/api-endpoin
 import {SelectPropertyValue} from '@notionhq/client/build/src/api-types';
 
 function removeHTML(text: string): string {
-  return text.replace(/<.*>.*<\/.*>/g, '');
+  return text ? text.replace(/<.*>.*<\/.*>/g, '') : '';
 }
 
 function getStatusSelectOption(state: 'open' | 'closed'): Omit<SelectPropertyValue, 'id'> {

--- a/src/action.ts
+++ b/src/action.ts
@@ -6,8 +6,8 @@ import {properties} from './properties';
 import type {InputPropertyValueMap} from '@notionhq/client/build/src/api-endpoints';
 import {SelectPropertyValue} from '@notionhq/client/build/src/api-types';
 
-function removeHTML(text: string): string {
-  return text ? text.replace(/<.*>.*<\/.*>/g, '') : '';
+function removeHTML(text?: string): string {
+  return text?.replace(/<.*>.*<\/.*>/g, '') ?? '';
 }
 
 function getStatusSelectOption(state: 'open' | 'closed'): Omit<SelectPropertyValue, 'id'> {


### PR DESCRIPTION
If an issue is created with an empty body, the action failed when calling `replace` on `null`. This PR updates the `removeHTML` function to return an empty string if the `text` argument is `null`.

Fixes #31 