### PR TITLE
Remove npm publish from release-it config

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -6,7 +6,7 @@
     "release": true
   },
   "npm": {
-    "publish": true
+    "publish": false
   }
 }
 


### PR DESCRIPTION
Remove npm publish from release-it config since this is a github action and doesn't need to be published to npm