### PR TITLE
feat: make `github-token` optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ jobs:
         with:
           notion-token: ${{ secrets.NOTION_TOKEN }}
           notion-db: ${{ secrets.NOTION_DATABASE }}
+
+          # This token is optional, it defaults to the built-in GITHUB_TOKEN.
+          # You can still use any PAT, provided that it has access to your issues.
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,6 @@ jobs:
         with:
           notion-token: ${{ secrets.NOTION_TOKEN }}
           notion-db: ${{ secrets.NOTION_DATABASE }}
-
-          # This token is optional, it defaults to the built-in GITHUB_TOKEN.
-          # You can still use any PAT, provided that it has access to your issues.
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 8. (Optional) If your Github repository has any preexisting issues that you would like to sync to your new Notion Database you can trigger a manual workflow. Make sure your organization's default `GITHUB_TOKEN` has [read and write permissions](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#setting-the-permissions-of-the-github_token-for-your-organization) then follow [these intructions](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) to run the `Notion Job` workflow.

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,8 @@ inputs:
     required: true
   github-token:
     description: 'Your GitHub personal access token'
-    required: true
+    required: false
+    default: ${{ github.token }}
 
 runs:
   using: 'node12'


### PR DESCRIPTION
This fixes #44 

I'm not really sure if this is the best way to document the fact that it's not required, what do you think about it?